### PR TITLE
Removed unnecessary copying

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,7 +37,7 @@ impl NibbleVec {
     pub fn from_byte_vec(vec: Vec<u8>) -> NibbleVec {
         let length = 2 * vec.len();
         NibbleVec {
-            length: length,
+            length,
             data: vec
         }
     }
@@ -202,7 +202,7 @@ impl NibbleVec {
         // If the length is even, we can append directly.
         if self.length % 2 == 0 {
             self.length += other.length;
-            self.data.extend(other.data.clone());
+            self.data.extend(other.data.iter());
             return self;
         }
 
@@ -251,14 +251,14 @@ impl PartialEq<[u8]> for NibbleVec {
 
 impl Debug for NibbleVec {
     fn fmt(&self, fmt: &mut Formatter) -> fmt::Result {
-        try!(write!(fmt, "NibbleVec ["));
+        write!(fmt, "NibbleVec [")?;
 
         if !self.is_empty() {
-            try!(write!(fmt, "{}", self.get(0)));
+            write!(fmt, "{}", self.get(0))?;
         }
 
         for i in 1 .. self.len() {
-            try!(write!(fmt, ", {}", self.get(i)));
+            write!(fmt, ", {}", self.get(i))?;
         }
         write!(fmt, "]")
     }


### PR DESCRIPTION
Used operation `?`