### PR TITLE
Smallvec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /Cargo.lock
 *.swp
 .DS_Store
+.vscode

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,10 @@ readme = "README.md"
 
 keywords = ["vector", "nibble", "slice", "data-structure", "collection"]
 categories = ["data-structures"]
+edition="2018"
+
+[dependencies]
+smallvec = "1.0"
 
 [dev-dependencies]
 criterion = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,5 +14,15 @@ readme = "README.md"
 keywords = ["vector", "nibble", "slice", "data-structure", "collection"]
 categories = ["data-structures"]
 
+[dev-dependencies]
+criterion = "0.3"
+
+[[bench]]
+name = "nib_bench"
+harness = false
+
+[lib]
+bench = false
+
 [badges]
 travis-ci = { repository = "michaelsproul/rust_nibble_vec" }

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ You can use it in your own projects by adding `nibble_vec` as a dependency in yo
 
 ```toml
 [dependencies]
-nibble_vec = "0.0.3"
+nibble_vec = "0.0.4"
 ```
 
 ## Documentation

--- a/benches/nib_bench.rs
+++ b/benches/nib_bench.rs
@@ -1,0 +1,56 @@
+use criterion::{criterion_group, criterion_main, Criterion};
+use nibble_vec::NibbleVec;
+
+fn v8_7_6_5() -> NibbleVec {
+    NibbleVec::from_byte_vec(vec![8 << 4 | 7, 6 << 4 | 5])
+}
+
+fn v11_10_9() -> NibbleVec {
+    let mut result = NibbleVec::from_byte_vec(vec![11 << 4 | 10]);
+    result.push(9);
+    result
+}
+
+fn split_test(nibble_vec: &NibbleVec, idx: usize, first: Vec<u8>, second: Vec<u8>) {
+    let mut init = nibble_vec.clone();
+    let tail = init.split(idx);
+    assert!(init == first[..]);
+    assert!(tail == second[..]);
+}
+
+fn nib_split_even(b: &mut Criterion) {
+    let even_length = v8_7_6_5();
+    b.bench_function("make nib vec", |b| b.iter(|| {
+        split_test(&even_length, 1, vec![8], vec![7, 6, 5]);
+        split_test(&even_length, 2, vec![8, 7], vec![6, 5]);
+    }));
+}
+
+fn nib_make_split(b: &mut Criterion) {
+    b.bench_function("nib_make_split", |b| {
+        b.iter(|| {
+            let odd_length = v11_10_9();
+            split_test(&odd_length, 0, vec![], vec![11, 10, 9]);
+            split_test(&odd_length, 1, vec![11], vec![10, 9]);
+        })
+    });
+}
+
+fn join_test(vec1: &NibbleVec, vec2: &NibbleVec, result: Vec<u8>) {
+    let joined = vec1.clone().join(vec2);
+    assert!(joined == result[..]);
+}
+
+fn nib_join_test(b: &mut Criterion) {
+    b.bench_function("trie remove", |b| {
+        b.iter(|| {
+            let v1 = v8_7_6_5();
+            let v2 = v11_10_9();
+            join_test(&v1, &v2, vec![8, 7, 6, 5, 11, 10, 9]);
+            join_test(&v1, &v1, vec![8, 7, 6, 5, 8, 7, 6, 5]);
+        });
+    });
+}
+
+criterion_group!(benches, nib_split_even, nib_make_split, nib_join_test);
+criterion_main!(benches);

--- a/benches/nib_bench.rs
+++ b/benches/nib_bench.rs
@@ -1,5 +1,5 @@
 use criterion::{criterion_group, criterion_main, Criterion};
-use nibble_vec::{Nibblet, NibbleVec};
+use nibble_vec::{NibbleVec, Nibblet};
 
 fn even_8to5() -> Nibblet {
     Nibblet::from_byte_vec(vec![8 << 4 | 7, 6 << 4 | 5])

--- a/benches/nib_bench.rs
+++ b/benches/nib_bench.rs
@@ -1,17 +1,17 @@
 use criterion::{criterion_group, criterion_main, Criterion};
-use nibble_vec::NibbleVec;
+use nibble_vec::{Nibblet, NibbleVec};
 
-fn even_8to5() -> NibbleVec {
-    NibbleVec::from_byte_vec(vec![8 << 4 | 7, 6 << 4 | 5])
+fn even_8to5() -> Nibblet {
+    Nibblet::from_byte_vec(vec![8 << 4 | 7, 6 << 4 | 5])
 }
 
-fn odd_11to9() -> NibbleVec {
-    let mut result = NibbleVec::from_byte_vec(vec![11 << 4 | 10]);
+fn odd_11to9() -> Nibblet {
+    let mut result = Nibblet::from_byte_vec(vec![11 << 4 | 10]);
     result.push(9);
     result
 }
 
-fn split_test(nibble_vec: &NibbleVec, idx: usize) {
+fn split_test(nibble_vec: &Nibblet, idx: usize) {
     let mut init = nibble_vec.clone();
     let _tail = init.split(idx);
 }
@@ -39,7 +39,7 @@ fn nib_make_split_bench(b: &mut Criterion) {
 fn nib_get_bench(b: &mut Criterion) {
     b.bench_function("nib get on vec of 9 elements", |b| {
         let v = vec![243, 2, 3, 251, 5, 6, 7, 8, 255];
-        let nv = NibbleVec::from(v.clone());
+        let nv = Nibblet::from(v.clone());
         b.iter(|| {
             for (i, _) in v.iter().enumerate() {
                 nv.get(i);
@@ -48,7 +48,7 @@ fn nib_get_bench(b: &mut Criterion) {
     });
 }
 
-fn join_test(vec1: &NibbleVec, vec2: &NibbleVec) {
+fn join_test(vec1: &Nibblet, vec2: &Nibblet) {
     let _joined = vec1.clone().join(vec2);
 }
 
@@ -67,18 +67,18 @@ fn nib_from_into_bench(b: &mut Criterion) {
     b.bench_function("nib from vec and into vec", |b| {
         b.iter(|| {
             let x = vec![10, 11, 12, 13, 14, 15, 16];
-            let nv = NibbleVec::from_byte_vec(x);
+            let nv = Nibblet::from_byte_vec(x);
             let v: Vec<u8> = nv.into();
-            let _nv2 = NibbleVec::from(v);
+            let _nv2 = Nibblet::from(v);
         });
     });
 }
 
 fn nib_cmp_bench(b: &mut Criterion) {
     b.bench_function("bench eq and not eq", |b| {
-        let nv = NibbleVec::from_byte_vec(vec![10, 11, 12, 13, 14, 15, 16]);
-        let nv_eq = NibbleVec::from_byte_vec(vec![10, 11, 12, 13, 14, 15, 16]);
-        let nv_not_eq = NibbleVec::from_byte_vec(vec![1, 1, 2, 3, 4, 5, 6]);
+        let nv = Nibblet::from_byte_vec(vec![10, 11, 12, 13, 14, 15, 16]);
+        let nv_eq = Nibblet::from_byte_vec(vec![10, 11, 12, 13, 14, 15, 16]);
+        let nv_not_eq = Nibblet::from_byte_vec(vec![1, 1, 2, 3, 4, 5, 6]);
         b.iter(|| {
             let _a = nv == nv_eq;
             let _b = nv == nv_not_eq;

--- a/benches/nib_bench.rs
+++ b/benches/nib_bench.rs
@@ -77,6 +77,7 @@ criterion_group!(
     nib_split_even_bench,
     nib_make_split_bench,
     nib_join_bench,
-    nib_get_bench
+    nib_get_bench,
+    nib_from_into_bench
 );
 criterion_main!(benches);

--- a/benches/nib_bench.rs
+++ b/benches/nib_bench.rs
@@ -18,16 +18,16 @@ fn split_test(nibble_vec: &NibbleVec, idx: usize) {
 
 fn nib_split_even_bench(b: &mut Criterion) {
     let even_length = even_8to5();
-    b.bench_function("split even not including building the vec", |b| b.iter(|| {
+    b.bench_function("nibvec split even", |b| b.iter(|| {
         split_test(&even_length, 1);
         split_test(&even_length, 2);
     }));
 }
 
 fn nib_make_split_bench(b: &mut Criterion) {
-    b.bench_function("nib build nibvec split odd len", |b| {
+    b.bench_function("nibvec split odd", |b| {
+        let odd_length = odd_11to9();
         b.iter(|| {
-            let odd_length = odd_11to9();
             split_test(&odd_length, 0);
             split_test(&odd_length, 1);
         })

--- a/benches/nib_bench.rs
+++ b/benches/nib_bench.rs
@@ -1,56 +1,65 @@
 use criterion::{criterion_group, criterion_main, Criterion};
 use nibble_vec::NibbleVec;
 
-fn v8_7_6_5() -> NibbleVec {
+fn even_8to5() -> NibbleVec {
     NibbleVec::from_byte_vec(vec![8 << 4 | 7, 6 << 4 | 5])
 }
 
-fn v11_10_9() -> NibbleVec {
+fn odd_11to9() -> NibbleVec {
     let mut result = NibbleVec::from_byte_vec(vec![11 << 4 | 10]);
     result.push(9);
     result
 }
 
-fn split_test(nibble_vec: &NibbleVec, idx: usize, first: Vec<u8>, second: Vec<u8>) {
+fn split_test(nibble_vec: &NibbleVec, idx: usize) {
     let mut init = nibble_vec.clone();
-    let tail = init.split(idx);
-    assert!(init == first[..]);
-    assert!(tail == second[..]);
+    let _tail = init.split(idx);
 }
 
 fn nib_split_even(b: &mut Criterion) {
-    let even_length = v8_7_6_5();
+    let even_length = even_8to5();
     b.bench_function("make nib vec", |b| b.iter(|| {
-        split_test(&even_length, 1, vec![8], vec![7, 6, 5]);
-        split_test(&even_length, 2, vec![8, 7], vec![6, 5]);
+        split_test(&even_length, 1);
+        split_test(&even_length, 2);
     }));
 }
 
 fn nib_make_split(b: &mut Criterion) {
     b.bench_function("nib_make_split", |b| {
         b.iter(|| {
-            let odd_length = v11_10_9();
-            split_test(&odd_length, 0, vec![], vec![11, 10, 9]);
-            split_test(&odd_length, 1, vec![11], vec![10, 9]);
+            let odd_length = odd_11to9();
+            split_test(&odd_length, 0);
+            split_test(&odd_length, 1);
         })
     });
 }
 
-fn join_test(vec1: &NibbleVec, vec2: &NibbleVec, result: Vec<u8>) {
-    let joined = vec1.clone().join(vec2);
-    assert!(joined == result[..]);
+fn nib_get(b: &mut Criterion) {
+    b.bench_function("nib_make_split", |b| {
+        let v = vec![243, 2, 3, 251, 5, 6, 7, 8, 255];
+        let nv = NibbleVec::from(v.clone());
+        b.iter(|| {
+            for (i, _) in v.iter().enumerate() {
+                nv.get(i);
+            }
+        })
+    });
+}
+
+fn join_test(vec1: &NibbleVec, vec2: &NibbleVec) {
+    let _joined = vec1.clone().join(vec2);
 }
 
 fn nib_join_test(b: &mut Criterion) {
     b.bench_function("trie remove", |b| {
         b.iter(|| {
-            let v1 = v8_7_6_5();
-            let v2 = v11_10_9();
-            join_test(&v1, &v2, vec![8, 7, 6, 5, 11, 10, 9]);
-            join_test(&v1, &v1, vec![8, 7, 6, 5, 8, 7, 6, 5]);
+            let v1 = even_8to5();
+            let v2 = odd_11to9();
+            join_test(&v1, &v2);
+            join_test(&v1, &v1);
         });
     });
 }
 
-criterion_group!(benches, nib_split_even, nib_make_split, nib_join_test);
+criterion_group!(benches, nib_split_even, nib_make_split, nib_join_test, nib_get);
 criterion_main!(benches);

--- a/benches/nib_bench.rs
+++ b/benches/nib_bench.rs
@@ -72,12 +72,26 @@ fn nib_from_into_bench(b: &mut Criterion) {
     });
 }
 
+fn nib_cmp_bench(b: &mut Criterion) {
+    b.bench_function("bench eq and not eq", |b| {
+        let nv = NibbleVec::from_byte_vec(vec![10, 11, 12, 13, 14, 15, 16]);
+        let nv_eq = NibbleVec::from_byte_vec(vec![10, 11, 12, 13, 14, 15, 16]);
+        let nv_not_eq = NibbleVec::from_byte_vec(vec![1, 1, 2, 3, 4, 5, 6]);
+        b.iter(|| {
+            let _a = nv == nv_eq;
+            let _b = nv == nv_not_eq;
+            let _c = nv_eq != nv_not_eq;
+        });
+    });
+}
+
 criterion_group!(
     benches,
     nib_split_even_bench,
     nib_make_split_bench,
     nib_join_bench,
     nib_get_bench,
-    nib_from_into_bench
+    nib_from_into_bench,
+    nib_cmp_bench
 );
 criterion_main!(benches);

--- a/benches/nib_bench.rs
+++ b/benches/nib_bench.rs
@@ -18,10 +18,12 @@ fn split_test(nibble_vec: &NibbleVec, idx: usize) {
 
 fn nib_split_even_bench(b: &mut Criterion) {
     let even_length = even_8to5();
-    b.bench_function("nibvec split even", |b| b.iter(|| {
-        split_test(&even_length, 1);
-        split_test(&even_length, 2);
-    }));
+    b.bench_function("nibvec split even", |b| {
+        b.iter(|| {
+            split_test(&even_length, 1);
+            split_test(&even_length, 2);
+        })
+    });
 }
 
 fn nib_make_split_bench(b: &mut Criterion) {

--- a/benches/nib_bench.rs
+++ b/benches/nib_bench.rs
@@ -16,7 +16,7 @@ fn split_test(nibble_vec: &NibbleVec, idx: usize) {
     let _tail = init.split(idx);
 }
 
-fn nib_split_even(b: &mut Criterion) {
+fn nib_split_even_bench(b: &mut Criterion) {
     let even_length = even_8to5();
     b.bench_function("split even not including building the vec", |b| b.iter(|| {
         split_test(&even_length, 1);
@@ -24,7 +24,7 @@ fn nib_split_even(b: &mut Criterion) {
     }));
 }
 
-fn nib_make_split(b: &mut Criterion) {
+fn nib_make_split_bench(b: &mut Criterion) {
     b.bench_function("nib build nibvec split odd len", |b| {
         b.iter(|| {
             let odd_length = odd_11to9();
@@ -34,7 +34,7 @@ fn nib_make_split(b: &mut Criterion) {
     });
 }
 
-fn nib_get(b: &mut Criterion) {
+fn nib_get_bench(b: &mut Criterion) {
     b.bench_function("nib get on vec of 9 elements", |b| {
         let v = vec![243, 2, 3, 251, 5, 6, 7, 8, 255];
         let nv = NibbleVec::from(v.clone());
@@ -50,7 +50,7 @@ fn join_test(vec1: &NibbleVec, vec2: &NibbleVec) {
     let _joined = vec1.clone().join(vec2);
 }
 
-fn nib_join_test(b: &mut Criterion) {
+fn nib_join_bench(b: &mut Criterion) {
     b.bench_function("join even nibvec to odd nib", |b| {
         b.iter(|| {
             let v1 = even_8to5();
@@ -61,5 +61,22 @@ fn nib_join_test(b: &mut Criterion) {
     });
 }
 
-criterion_group!(benches, nib_split_even, nib_make_split, nib_join_test, nib_get);
+fn nib_from_into_bench(b: &mut Criterion) {
+    b.bench_function("nib from vec and into vec", |b| {
+        b.iter(|| {
+            let x = vec![10, 11, 12, 13, 14, 15, 16];
+            let nv = NibbleVec::from_byte_vec(x);
+            let v: Vec<u8> = nv.into();
+            let _nv2 = NibbleVec::from(v);
+        });
+    });
+}
+
+criterion_group!(
+    benches,
+    nib_split_even_bench,
+    nib_make_split_bench,
+    nib_join_bench,
+    nib_get_bench
+);
 criterion_main!(benches);

--- a/benches/nib_bench.rs
+++ b/benches/nib_bench.rs
@@ -18,14 +18,14 @@ fn split_test(nibble_vec: &NibbleVec, idx: usize) {
 
 fn nib_split_even(b: &mut Criterion) {
     let even_length = even_8to5();
-    b.bench_function("make nib vec", |b| b.iter(|| {
+    b.bench_function("split even not including building the vec", |b| b.iter(|| {
         split_test(&even_length, 1);
         split_test(&even_length, 2);
     }));
 }
 
 fn nib_make_split(b: &mut Criterion) {
-    b.bench_function("nib_make_split", |b| {
+    b.bench_function("nib build nibvec split odd len", |b| {
         b.iter(|| {
             let odd_length = odd_11to9();
             split_test(&odd_length, 0);
@@ -35,7 +35,7 @@ fn nib_make_split(b: &mut Criterion) {
 }
 
 fn nib_get(b: &mut Criterion) {
-    b.bench_function("nib_make_split", |b| {
+    b.bench_function("nib get on vec of 9 elements", |b| {
         let v = vec![243, 2, 3, 251, 5, 6, 7, 8, 255];
         let nv = NibbleVec::from(v.clone());
         b.iter(|| {
@@ -51,7 +51,7 @@ fn join_test(vec1: &NibbleVec, vec2: &NibbleVec) {
 }
 
 fn nib_join_test(b: &mut Criterion) {
-    b.bench_function("trie remove", |b| {
+    b.bench_function("join even nibvec to odd nib", |b| {
         b.iter(|| {
             let v1 = even_8to5();
             let v2 = odd_11to9();

--- a/examples/debug.rs
+++ b/examples/debug.rs
@@ -1,9 +1,9 @@
 extern crate nibble_vec;
 
-use nibble_vec::NibbleVec;
+use nibble_vec::Nibblet;
 
 fn main() {
-    let mut v = NibbleVec::from_byte_vec(vec![1 << 4 | 11, 2 << 4 | 12, 3 << 4 | 13]);
+    let mut v = Nibblet::from_byte_vec(vec![1 << 4 | 11, 2 << 4 | 12, 3 << 4 | 13]);
     v.push(4);
     println!("{:?}", v);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,9 +3,9 @@ mod test;
 
 use smallvec::SmallVec;
 
-use std::iter::FromIterator;
 use std::convert::{From, Into};
 use std::fmt::{self, Debug, Formatter};
+use std::iter::FromIterator;
 
 /// A data-structure for storing a sequence of 4-bit values.
 ///
@@ -40,7 +40,10 @@ impl NibbleVec {
     #[inline]
     pub fn from_byte_vec(vec: Vec<u8>) -> NibbleVec {
         let length = 2 * vec.len();
-        NibbleVec { length, data: SmallVec::from_iter(vec) }
+        NibbleVec {
+            length,
+            data: SmallVec::from_iter(vec),
+        }
     }
 
     /// Create a nibble vector from a `SmallVec` of Size.
@@ -48,7 +51,10 @@ impl NibbleVec {
     /// Each byte is split into two 4-bit entries (MSB, LSB).
     #[inline]
     pub fn from_small_vec(length: usize) -> NibbleVec {
-        NibbleVec { length, data: SmallVec::new() }
+        NibbleVec {
+            length,
+            data: SmallVec::new(),
+        }
     }
 
     /// Returns a byte slice of the nibble vector's contents.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,7 @@ pub struct NibbleVec {
     length: usize,
     data: SmallVec<[u8; 20]>,
 }
-
+// TODO add trait to make size generic
 impl NibbleVec {
     /// Create an empty nibble vector.
     pub fn new() -> NibbleVec {
@@ -41,6 +41,14 @@ impl NibbleVec {
     pub fn from_byte_vec(vec: Vec<u8>) -> NibbleVec {
         let length = 2 * vec.len();
         NibbleVec { length, data: SmallVec::from_iter(vec) }
+    }
+
+    /// Create a nibble vector from a `SmallVec` of Size.
+    ///
+    /// Each byte is split into two 4-bit entries (MSB, LSB).
+    #[inline]
+    pub fn from_small_vec(length: usize) -> NibbleVec {
+        NibbleVec { length, data: SmallVec::new() }
     }
 
     /// Returns a byte slice of the nibble vector's contents.
@@ -135,7 +143,7 @@ impl NibbleVec {
     #[inline]
     fn split_odd(&mut self, idx: usize) -> NibbleVec {
         let tail_vec_size = (self.length - idx) / 2;
-        let mut tail = NibbleVec::from_byte_vec(Vec::with_capacity(tail_vec_size));
+        let mut tail = NibbleVec::from_small_vec(tail_vec_size);
 
         // Perform an overlap copy, copying the last nibble of the original vector only if
         // the length of the new tail is *odd*.
@@ -173,7 +181,7 @@ impl NibbleVec {
         //        l_v = self.length
         let tail_vec_size = (self.length - idx + 1) / 2;
         let half_idx = idx / 2;
-        let mut tail = NibbleVec::from_byte_vec(Vec::with_capacity(tail_vec_size));
+        let mut tail = NibbleVec::from_small_vec(tail_vec_size);
 
         // Copy the bytes.
         for i in half_idx..self.data.len() {
@@ -299,24 +307,28 @@ impl Debug for NibbleVec {
 }
 
 impl From<Vec<u8>> for NibbleVec {
+    #[inline]
     fn from(v: Vec<u8>) -> NibbleVec {
         NibbleVec::from_byte_vec(v)
     }
 }
 
 impl<'a> From<&'a [u8]> for NibbleVec {
+    #[inline]
     fn from(v: &[u8]) -> NibbleVec {
         NibbleVec::from_byte_vec(v.into())
     }
 }
 
 impl Into<Vec<u8>> for NibbleVec {
+    #[inline]
     fn into(self) -> Vec<u8> {
         self.data.to_vec()
     }
 }
 
 impl<'a> Into<Vec<u8>> for &'a NibbleVec {
+    #[inline]
     fn into(self) -> Vec<u8> {
         self.data.to_vec()
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -149,7 +149,7 @@ impl NibbleVec {
     #[inline]
     fn split_odd(&mut self, idx: usize) -> NibbleVec {
         let tail_vec_size = (self.length - idx) / 2;
-        let mut tail = NibbleVec::from_small_vec(tail_vec_size);
+        let mut tail = NibbleVec::from_small_vec(0);
 
         // Perform an overlap copy, copying the last nibble of the original vector only if
         // the length of the new tail is *odd*.
@@ -187,7 +187,7 @@ impl NibbleVec {
         //        l_v = self.length
         let tail_vec_size = (self.length - idx + 1) / 2;
         let half_idx = idx / 2;
-        let mut tail = NibbleVec::from_small_vec(tail_vec_size);
+        let mut tail = NibbleVec::from_small_vec(0);
 
         // Copy the bytes.
         for i in half_idx..self.data.len() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,6 +36,7 @@ impl NibbleVec {
     /// Create a nibble vector from a vector of bytes.
     ///
     /// Each byte is split into two 4-bit entries (MSB, LSB).
+    #[inline]
     pub fn from_byte_vec(vec: Vec<u8>) -> NibbleVec {
         let length = 2 * vec.len();
         NibbleVec { length, data: SmallVec::from(vec) }
@@ -255,6 +256,7 @@ impl NibbleVec {
 }
 
 impl PartialEq<NibbleVec> for NibbleVec {
+    #[inline]
     fn eq(&self, other: &NibbleVec) -> bool {
         self.length == other.length && self.data == other.data
     }
@@ -265,6 +267,7 @@ impl Eq for NibbleVec {}
 /// Compare a `NibbleVec` and a slice of bytes *element-by-element*.
 /// Bytes are **not** interpreted as two `NibbleVec` entries.
 impl PartialEq<[u8]> for NibbleVec {
+    #[inline]
     fn eq(&self, other: &[u8]) -> bool {
         if other.len() != self.len() {
             return false;
@@ -295,28 +298,24 @@ impl Debug for NibbleVec {
 }
 
 impl From<Vec<u8>> for NibbleVec {
-    #[inline]
     fn from(v: Vec<u8>) -> NibbleVec {
         NibbleVec::from_byte_vec(v)
     }
 }
 
 impl<'a> From<&'a [u8]> for NibbleVec {
-    #[inline]
     fn from(v: &[u8]) -> NibbleVec {
         NibbleVec::from_byte_vec(v.into())
     }
 }
 
 impl Into<Vec<u8>> for NibbleVec {
-    #[inline]
     fn into(self) -> Vec<u8> {
         self.data.to_vec()
     }
 }
 
 impl<'a> Into<Vec<u8>> for &'a NibbleVec {
-    #[inline]
     fn into(self) -> Vec<u8> {
         self.data.to_vec()
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,6 +42,7 @@ impl NibbleVec {
     }
 
     /// Returns a byte slice of the nibble vector's contents.
+    #[inline]
     pub fn as_bytes(&self) -> &[u8] {
         &self.data[..]
     }
@@ -49,16 +50,19 @@ impl NibbleVec {
     /// Converts a nibble vector into a byte vector.
     ///
     /// This consumes the nibble vector, so we do not need to copy its contents.
+    #[inline]
     pub fn into_bytes(self) -> Vec<u8> {
         self.data.to_vec()
     }
 
     /// Get the number of elements stored in the vector.
+    #[inline]
     pub fn len(&self) -> usize {
         self.length
     }
 
     /// Returns `true` if the nibble vector has a length of 0.
+    #[inline]
     pub fn is_empty(&self) -> bool {
         self.data.is_empty()
     }
@@ -68,6 +72,7 @@ impl NibbleVec {
     /// Guaranteed to be a value in the interval [0, 15].
     ///
     /// **Panics** if `idx >= self.len()`.
+    #[inline]
     pub fn get(&self, idx: usize) -> u8 {
         if idx >= self.length {
             panic!(
@@ -87,6 +92,7 @@ impl NibbleVec {
     /// Add a single nibble to the vector.
     ///
     /// Only the 4 least-significant bits of the value are used.
+    #[inline]
     pub fn push(&mut self, val: u8) {
         if self.length % 2 == 0 {
             self.data.push(val << 4);
@@ -187,7 +193,7 @@ impl NibbleVec {
     /// Copy data between the second half of self.data[start] and
     /// self.data[end - 1]. The second half of the last entry is included
     /// if include_last is true.
-    #[inline(always)]
+    #[inline]
     fn overlap_copy(
         &self,
         start: usize,
@@ -216,6 +222,7 @@ impl NibbleVec {
     }
 
     /// Append another nibble vector whilst consuming this vector.
+    #[inline]
     pub fn join(mut self, other: &NibbleVec) -> NibbleVec {
         // If the length is even, we can append directly.
         if self.length % 2 == 0 {
@@ -288,24 +295,28 @@ impl Debug for NibbleVec {
 }
 
 impl From<Vec<u8>> for NibbleVec {
+    #[inline]
     fn from(v: Vec<u8>) -> NibbleVec {
         NibbleVec::from_byte_vec(v)
     }
 }
 
 impl<'a> From<&'a [u8]> for NibbleVec {
+    #[inline]
     fn from(v: &[u8]) -> NibbleVec {
         NibbleVec::from_byte_vec(v.into())
     }
 }
 
 impl Into<Vec<u8>> for NibbleVec {
+    #[inline]
     fn into(self) -> Vec<u8> {
         self.data.to_vec()
     }
 }
 
 impl<'a> Into<Vec<u8>> for &'a NibbleVec {
+    #[inline]
     fn into(self) -> Vec<u8> {
         self.data.to_vec()
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ mod test;
 
 use smallvec::SmallVec;
 
+use std::iter::FromIterator;
 use std::convert::{From, Into};
 use std::fmt::{self, Debug, Formatter};
 
@@ -29,7 +30,7 @@ impl NibbleVec {
     pub fn new() -> NibbleVec {
         NibbleVec {
             length: 0,
-            data: SmallVec::default(),
+            data: SmallVec::new(),
         }
     }
 
@@ -39,7 +40,7 @@ impl NibbleVec {
     #[inline]
     pub fn from_byte_vec(vec: Vec<u8>) -> NibbleVec {
         let length = 2 * vec.len();
-        NibbleVec { length, data: SmallVec::from(vec) }
+        NibbleVec { length, data: SmallVec::from_iter(vec) }
     }
 
     /// Returns a byte slice of the nibble vector's contents.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,12 +23,12 @@ pub type Nibblet = NibbleVec<[u8; 64]>;
 ///
 /// [msb-wiki]: http://en.wikipedia.org/wiki/Most_significant_bit
 #[derive(Clone, Default)]
-pub struct NibbleVec<A: Array<Item=u8>> {
+pub struct NibbleVec<A: Array<Item = u8>> {
     length: usize,
     data: SmallVec<A>,
 }
 
-impl<A: Array<Item=u8>> NibbleVec<A> {
+impl<A: Array<Item = u8>> NibbleVec<A> {
     /// Create an empty nibble vector.
     pub fn new() -> NibbleVec<A> {
         NibbleVec {
@@ -188,7 +188,7 @@ impl<A: Array<Item=u8>> NibbleVec<A> {
         // Possible to prove: l_d - ⌊i / 2⌋ = ⌊(l_v - i + 1) / 2⌋
         //  where l_d = self.data.len()
         //        l_v = self.length
-        
+
         // let tail_vec_size = (self.length - idx + 1) / 2;
         let half_idx = idx / 2;
         let mut tail = NibbleVec::from_small_vec(0);
@@ -274,18 +274,18 @@ impl<A: Array<Item=u8>> NibbleVec<A> {
     }
 }
 
-impl<A: Array<Item=u8>> PartialEq<NibbleVec<A>> for NibbleVec<A> {
+impl<A: Array<Item = u8>> PartialEq<NibbleVec<A>> for NibbleVec<A> {
     #[inline]
     fn eq(&self, other: &NibbleVec<A>) -> bool {
         self.length == other.length && self.data == other.data
     }
 }
 
-impl<A: Array<Item=u8>> Eq for NibbleVec<A> {}
+impl<A: Array<Item = u8>> Eq for NibbleVec<A> {}
 
 /// Compare a `NibbleVec` and a slice of bytes *element-by-element*.
 /// Bytes are **not** interpreted as two `NibbleVec` entries.
-impl<A: Array<Item=u8>> PartialEq<[u8]> for NibbleVec<A> {
+impl<A: Array<Item = u8>> PartialEq<[u8]> for NibbleVec<A> {
     #[inline]
     fn eq(&self, other: &[u8]) -> bool {
         if other.len() != self.len() {
@@ -301,7 +301,7 @@ impl<A: Array<Item=u8>> PartialEq<[u8]> for NibbleVec<A> {
     }
 }
 
-impl<A: Array<Item=u8>> Debug for NibbleVec<A> {
+impl<A: Array<Item = u8>> Debug for NibbleVec<A> {
     fn fmt(&self, fmt: &mut Formatter) -> fmt::Result {
         write!(fmt, "NibbleVec [")?;
 
@@ -316,28 +316,28 @@ impl<A: Array<Item=u8>> Debug for NibbleVec<A> {
     }
 }
 
-impl<A: Array<Item=u8>> From<Vec<u8>> for NibbleVec<A> {
+impl<A: Array<Item = u8>> From<Vec<u8>> for NibbleVec<A> {
     #[inline]
     fn from(v: Vec<u8>) -> NibbleVec<A> {
         NibbleVec::from_byte_vec(v)
     }
 }
 
-impl<'a, A: Array<Item=u8>> From<&'a [u8]> for NibbleVec<A> {
+impl<'a, A: Array<Item = u8>> From<&'a [u8]> for NibbleVec<A> {
     #[inline]
     fn from(v: &[u8]) -> NibbleVec<A> {
         NibbleVec::from_byte_vec(v.into())
     }
 }
 
-impl<A: Array<Item=u8>> Into<Vec<u8>> for NibbleVec<A> {
+impl<A: Array<Item = u8>> Into<Vec<u8>> for NibbleVec<A> {
     #[inline]
     fn into(self) -> Vec<u8> {
         self.data.to_vec()
     }
 }
 
-impl<'a, A: Array<Item=u8>> Into<Vec<u8>> for &'a NibbleVec<A> {
+impl<'a, A: Array<Item = u8>> Into<Vec<u8>> for &'a NibbleVec<A> {
     #[inline]
     fn into(self) -> Vec<u8> {
         self.data.to_vec()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -135,6 +135,7 @@ impl<A: Array<Item = u8>> NibbleVec<A> {
     ///
     /// **Panics** if `idx > self.len()`.
     pub fn split(&mut self, idx: usize) -> NibbleVec<A> {
+        // assert! is a few percent slower surprisingly
         if idx > self.length {
             panic!(
                 "attempted to split past vector end. len is {}, index is {}",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,8 @@ use std::convert::{From, Into};
 use std::fmt::{self, Debug, Formatter};
 use std::iter::FromIterator;
 
-/// Type for easy use if you don't want generics all over the place.
+/// A `NibbleVec` backed by a `SmallVec` with 64 inline element slots.
+/// This will not allocate until more than 64 elements are added.
 pub type Nibblet = NibbleVec<[u8; 64]>;
 
 /// A data-structure for storing a sequence of 4-bit values.

--- a/src/test.rs
+++ b/src/test.rs
@@ -1,4 +1,4 @@
-use NibbleVec;
+use crate::NibbleVec;
 
 fn v8_7_6_5() -> NibbleVec {
     NibbleVec::from_byte_vec(vec![8 << 4 | 7, 6 << 4 | 5])

--- a/src/test.rs
+++ b/src/test.rs
@@ -1,25 +1,25 @@
-use crate::NibbleVec;
+use crate::{NibbleVec, Nibblet};
 
-fn v8_7_6_5() -> NibbleVec {
+fn v8_7_6_5() -> Nibblet {
     NibbleVec::from_byte_vec(vec![8 << 4 | 7, 6 << 4 | 5])
 }
 
-fn v11_10_9() -> NibbleVec {
-    let mut result = NibbleVec::from_byte_vec(vec![11 << 4 | 10]);
+fn v11_10_9() -> Nibblet {
+    let mut result = Nibblet::from_byte_vec(vec![11 << 4 | 10]);
     result.push(9);
     result
 }
 
 #[test]
 fn get() {
-    let nv = NibbleVec::from_byte_vec(vec![3 << 4 | 7]);
+    let nv = Nibblet::from_byte_vec(vec![3 << 4 | 7]);
     assert_eq!(nv.get(0), 3u8);
     assert_eq!(nv.get(1), 7u8);
 }
 
 #[test]
 fn push() {
-    let mut nv = NibbleVec::new();
+    let mut nv = Nibblet::new();
     let data = vec![0, 1, 3, 5, 7, 9, 11, 15];
     for val in data.iter() {
         nv.push(*val);
@@ -30,7 +30,7 @@ fn push() {
     }
 }
 
-fn split_test(nibble_vec: &NibbleVec, idx: usize, first: Vec<u8>, second: Vec<u8>) {
+fn split_test(nibble_vec: &Nibblet, idx: usize, first: Vec<u8>, second: Vec<u8>) {
     let mut init = nibble_vec.clone();
     let tail = init.split(idx);
     assert!(init == first[..]);
@@ -56,7 +56,7 @@ fn split_odd_length() {
 }
 
 /// Join vec2 onto vec1 and ensure that the results matches the one expected.
-fn join_test(vec1: &NibbleVec, vec2: &NibbleVec, result: Vec<u8>) {
+fn join_test(vec1: &Nibblet, vec2: &Nibblet, result: Vec<u8>) {
     let joined = vec1.clone().join(vec2);
     assert!(joined == result[..]);
 }
@@ -67,8 +67,8 @@ fn join_even_length() {
     let v2 = v11_10_9();
     join_test(&v1, &v2, vec![8, 7, 6, 5, 11, 10, 9]);
     join_test(&v1, &v1, vec![8, 7, 6, 5, 8, 7, 6, 5]);
-    join_test(&v1, &NibbleVec::new(), vec![8, 7, 6, 5]);
-    join_test(&NibbleVec::new(), &v1, vec![8, 7, 6, 5]);
+    join_test(&v1, &Nibblet::new(), vec![8, 7, 6, 5]);
+    join_test(&Nibblet::new(), &v1, vec![8, 7, 6, 5]);
 }
 
 #[test]
@@ -77,11 +77,12 @@ fn join_odd_length() {
     let v2 = v11_10_9();
     join_test(&v2, &v1, vec![11, 10, 9, 8, 7, 6, 5]);
     join_test(&v2, &v2, vec![11, 10, 9, 11, 10, 9]);
-    join_test(&v2, &NibbleVec::new(), vec![11, 10, 9]);
+    join_test(&v2, &Nibblet::new(), vec![11, 10, 9]);
 }
 
 #[test]
 fn clone() {
+    #[allow(clippy::redundant_clone)]
     let v1 = v8_7_6_5().clone();
     assert_eq!(v1.len(), 4);
 }
@@ -89,10 +90,9 @@ fn clone() {
 /// Ensure that the last nibble is zeroed before reuse.
 #[test]
 fn memory_reuse() {
-    let mut vec = NibbleVec::new();
+    let mut vec = Nibblet::new();
     vec.push(10);
     vec.push(1);
-
     // Pushing.
     vec.split(1);
     vec.push(2);
@@ -100,17 +100,17 @@ fn memory_reuse() {
 
     // Joining.
     vec.split(1);
-    vec = vec.join(&NibbleVec::from_byte_vec(vec![1 << 4 | 3, 5 << 4]));
+    vec = vec.join(&Nibblet::from_byte_vec(vec![1 << 4 | 3, 5 << 4]));
     assert_eq!(vec.get(1), 1);
 }
 
 #[test]
 fn from() {
     let v = vec![243, 2, 3, 251, 5, 6, 7, 8, 255];
-    let n = NibbleVec::from_byte_vec(v.clone());
-    let n2 = NibbleVec::from(&v[..]);
+    let n = Nibblet::from_byte_vec(v.clone());
+    let n2 = Nibblet::from(&v[..]);
     assert_eq!(n, n2);
-    let n3 = NibbleVec::from(v);
+    let n3 = Nibblet::from(v);
     assert_eq!(n, n3);
 }
 
@@ -118,12 +118,12 @@ fn from() {
 fn into() {
     let v = vec![243, 2, 3, 251, 5, 6, 7, 8, 255];
     {
-        let n = NibbleVec::from_byte_vec(v.clone());
+        let n = Nibblet::from_byte_vec(v.clone());
         let v2: Vec<u8> = n.into();
         assert_eq!(v, v2);
     }
     {
-        let n = NibbleVec::from_byte_vec(v.clone());
+        let n = Nibblet::from_byte_vec(v.clone());
         let v2: Vec<u8> = (&n).into();
         assert_eq!(v, v2);
     }
@@ -132,13 +132,13 @@ fn into() {
 #[test]
 fn as_bytes() {
     let v = vec![243, 2, 3, 251, 5, 6, 7, 8, 255];
-    let n = NibbleVec::from(&v[..]);
+    let n = Nibblet::from(&v[..]);
     assert_eq!(&v[..], n.as_bytes());
 }
 
 #[test]
 fn into_bytes() {
     let v = vec![243, 2, 3, 251, 5, 6, 7, 8, 255];
-    let n = NibbleVec::from(&v[..]);
+    let n = Nibblet::from(&v[..]);
     assert_eq!(v, n.into_bytes());
 }


### PR DESCRIPTION
added criterion benchmarking, changed backing `Vec` to use `SmallVec`, added more `#[inline]` statements but only if they improved performance and updated to 2018 edition.

```bash
  Finished bench [optimized] target(s) in 1m 02s
     Running target/release/deps/nib_bench-0d18aefb2e9989b1
nibvec split even       time:   [53.405 ns 53.590 ns 53.795 ns]                              
                        change: [-45.431% -45.297% -45.146%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  2 (2.00%) high mild
  6 (6.00%) high severe

nibvec split odd        time:   [52.705 ns 52.808 ns 52.928 ns]                             
                        change: [-26.002% -25.809% -25.593%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 9 outliers among 100 measurements (9.00%)
  2 (2.00%) low mild
  7 (7.00%) high mild

join even nibvec to odd nib                                                                            
                        time:   [92.310 ns 92.590 ns 92.904 ns]
                        change: [-30.711% -30.402% -30.103%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 9 outliers among 100 measurements (9.00%)
  9 (9.00%) high mild

nib get on vec of 9 elements                                                                             
                        time:   [6.8093 ns 6.8180 ns 6.8282 ns]
                        change: [-53.852% -53.810% -53.764%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 16 outliers among 100 measurements (16.00%)
  5 (5.00%) low mild
  3 (3.00%) high mild
  8 (8.00%) high severe

nib from vec and into vec                                                                             
                        time:   [45.538 ns 45.585 ns 45.639 ns]
                        change: [+29.609% +29.777% +29.950%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 10 outliers among 100 measurements (10.00%)
  2 (2.00%) low mild
  5 (5.00%) high mild
  3 (3.00%) high severe

bench eq and not eq     time:   [203.36 ps 203.39 ps 203.42 ps]                                
                        change: [-98.406% -98.385% -98.365%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high mild
```